### PR TITLE
Add OpenCV 9-ball rack ball tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-Yo, this is Grant's profile! Have a <b>groovy</b>, and <i>spiffy</i> day!
+# 9-Ball Rack Ball Tracker
+
+OpenCV-based tool that detects and tracks pool balls in top-down table video, highlights each ball with a circle, and overlays numbered labels (1–9) when color classification is confident.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+# Process a video and save annotated output
+python track_9ball_rack.py --input path/to/video.mp4 --output annotated.mp4
+
+# Show live preview while processing
+python track_9ball_rack.py --input path/to/video.mp4 --display
+
+# Tune HSV color ranges for your lighting and felt color
+python track_9ball_rack.py --input path/to/video.mp4 --calibrate
+```
+
+### CLI flags
+
+| Flag | Description |
+|------|-------------|
+| `--input` | Path to input video (required) |
+| `--output` | Path to save annotated MP4 |
+| `--display` | Show live preview window |
+| `--calibrate` | Interactive HSV slider mode for felt and ball colors |
+| `--scale` | Resize factor for processing (default: 1.0; use 0.5 for speed) |
+
+Press `q` in the preview window to quit early.
+
+## How it works
+
+1. **Felt masking** — Isolates the green/blue table surface to reduce false detections.
+2. **Circle detection** — Uses Hough circle transform to find ball candidates.
+3. **Color classification** — Maps HSV color in each ball's center to a ball number (1–9).
+4. **Stripe detection** — Distinguishes solid yellow (1) from striped yellow (9) via white-band ratio.
+5. **Tracking** — Associates detections across frames by nearest-neighbor matching so labels persist through movement.
+6. **Rack heuristics** — When balls are tightly clustered, uses diamond-rack geometry (apex → 1, center → 9) as a fallback.
+
+## Tuning tips
+
+- Use a **fixed overhead camera** with consistent lighting for best results.
+- If balls are missed or false positives appear, run `--calibrate` to adjust felt HSV bounds.
+- Ball radius scales with frame width automatically; very high or low camera angles may need a different `--scale`.
+- Hardest pairs to distinguish: **1 vs 9** (both yellow) and **7 vs 8** (both dark). Expect occasional mislabels under poor lighting.
+
+## Limitations
+
+- No deep-learning model — fast and lightweight, but not competition-grade accuracy.
+- Works best on standard APA/BCA ball colors over green or blue felt.
+- Overlapping balls in a tight rack may produce low-confidence labels until balls separate.

--- a/ball_colors.py
+++ b/ball_colors.py
@@ -1,0 +1,220 @@
+"""HSV color ranges and ball classification for standard pool balls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import cv2
+import numpy as np
+
+# Default felt HSV range (green table)
+DEFAULT_FELT_LOWER = np.array([35, 40, 40])
+DEFAULT_FELT_UPPER = np.array([85, 255, 255])
+
+# White stripe detection (for ball 9 vs ball 1)
+WHITE_LOWER = np.array([0, 0, 180])
+WHITE_UPPER = np.array([180, 60, 255])
+
+STRIPE_WHITE_RATIO_THRESHOLD = 0.12
+CLASSIFICATION_CONFIDENCE_THRESHOLD = 0.45
+
+
+@dataclass
+class ColorRange:
+    """HSV bounds for a ball color group."""
+
+    lower: np.ndarray
+    upper: np.ndarray
+    ball_numbers: tuple[int, ...]
+    label: str
+
+
+# Standard APA/BCA ball colors in HSV
+BALL_COLOR_RANGES: list[ColorRange] = [
+    ColorRange(
+        lower=np.array([18, 80, 80]),
+        upper=np.array([35, 255, 255]),
+        ball_numbers=(1, 9),
+        label="yellow",
+    ),
+    ColorRange(
+        lower=np.array([100, 80, 80]),
+        upper=np.array([130, 255, 255]),
+        ball_numbers=(2,),
+        label="blue",
+    ),
+    ColorRange(
+        lower=np.array([0, 120, 80]),
+        upper=np.array([10, 255, 255]),
+        ball_numbers=(3,),
+        label="red",
+    ),
+    ColorRange(
+        lower=np.array([125, 50, 50]),
+        upper=np.array([155, 255, 255]),
+        ball_numbers=(4,),
+        label="purple",
+    ),
+    ColorRange(
+        lower=np.array([10, 120, 120]),
+        upper=np.array([18, 255, 255]),
+        ball_numbers=(5,),
+        label="orange",
+    ),
+    ColorRange(
+        lower=np.array([40, 80, 80]),
+        upper=np.array([75, 255, 255]),
+        ball_numbers=(6,),
+        label="green",
+    ),
+    ColorRange(
+        lower=np.array([0, 80, 30]),
+        upper=np.array([10, 255, 120]),
+        ball_numbers=(7,),
+        label="maroon",
+    ),
+    ColorRange(
+        lower=np.array([0, 0, 0]),
+        upper=np.array([180, 80, 60]),
+        ball_numbers=(8,),
+        label="black",
+    ),
+]
+
+
+@dataclass
+class ClassificationResult:
+    ball_number: Optional[int]
+    confidence: float
+    label: str
+
+
+def create_felt_mask(hsv: np.ndarray, lower: np.ndarray, upper: np.ndarray) -> np.ndarray:
+    """Return binary mask of table felt."""
+    return cv2.inRange(hsv, lower, upper)
+
+
+def _sample_ball_region(
+    frame_bgr: np.ndarray,
+    hsv: np.ndarray,
+    cx: int,
+    cy: int,
+    radius: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Extract center region of a ball, avoiding edge bleed from felt."""
+    sample_r = max(2, int(radius * 0.5))
+    h, w = frame_bgr.shape[:2]
+    x1 = max(0, cx - sample_r)
+    y1 = max(0, cy - sample_r)
+    x2 = min(w, cx + sample_r)
+    y2 = min(h, cy + sample_r)
+    return hsv[y1:y2, x1:x2], frame_bgr[y1:y2, x1:x2]
+
+
+def _white_band_ratio(bgr_patch: np.ndarray) -> float:
+    """Ratio of white pixels in a horizontal band through the ball center."""
+    if bgr_patch.size == 0:
+        return 0.0
+    hsv_patch = cv2.cvtColor(bgr_patch, cv2.COLOR_BGR2HSV)
+    white_mask = cv2.inRange(hsv_patch, WHITE_LOWER, WHITE_UPPER)
+    mid = white_mask.shape[0] // 2
+    band_height = max(1, white_mask.shape[0] // 4)
+    y1 = max(0, mid - band_height // 2)
+    y2 = min(white_mask.shape[0], mid + band_height // 2)
+    band = white_mask[y1:y2, :]
+    if band.size == 0:
+        return 0.0
+    return float(np.count_nonzero(band)) / band.size
+
+
+def _color_match_score(hsv_patch: np.ndarray, color_range: ColorRange) -> float:
+    """Fraction of pixels matching a color range."""
+    if hsv_patch.size == 0:
+        return 0.0
+    mask = cv2.inRange(hsv_patch, color_range.lower, color_range.upper)
+    return float(np.count_nonzero(mask)) / mask.size
+
+
+def classify_ball(
+    frame_bgr: np.ndarray,
+    hsv: np.ndarray,
+    cx: int,
+    cy: int,
+    radius: int,
+) -> ClassificationResult:
+    """Classify a detected ball by dominant HSV color in its center."""
+    hsv_patch, bgr_patch = _sample_ball_region(frame_bgr, hsv, cx, cy, radius)
+    if hsv_patch.size == 0:
+        return ClassificationResult(None, 0.0, "Unknown")
+
+    best_range: Optional[ColorRange] = None
+    best_score = 0.0
+    for color_range in BALL_COLOR_RANGES:
+        score = _color_match_score(hsv_patch, color_range)
+        if score > best_score:
+            best_score = score
+            best_range = color_range
+
+    if best_range is None or best_score < CLASSIFICATION_CONFIDENCE_THRESHOLD:
+        return ClassificationResult(None, best_score, "Unknown")
+
+    ball_number: Optional[int] = None
+    if len(best_range.ball_numbers) == 1:
+        ball_number = best_range.ball_numbers[0]
+    elif best_range.label == "yellow":
+        white_ratio = _white_band_ratio(bgr_patch)
+        ball_number = 9 if white_ratio >= STRIPE_WHITE_RATIO_THRESHOLD else 1
+
+    label = str(ball_number) if ball_number is not None else "Unknown"
+    return ClassificationResult(ball_number, best_score, label)
+
+
+def run_calibration(frame_bgr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Interactive HSV calibration for felt color.
+    Adjust sliders, press 's' to save and exit, 'q' to cancel.
+    Returns (felt_lower, felt_upper) HSV arrays.
+    """
+    window = "Felt Calibration"
+    cv2.namedWindow(window)
+
+    def nothing(_: int) -> None:
+        pass
+
+    cv2.createTrackbar("H Low", window, 35, 179, nothing)
+    cv2.createTrackbar("S Low", window, 40, 255, nothing)
+    cv2.createTrackbar("V Low", window, 40, 255, nothing)
+    cv2.createTrackbar("H High", window, 85, 179, nothing)
+    cv2.createTrackbar("S High", window, 255, 255, nothing)
+    cv2.createTrackbar("V High", window, 255, 255, nothing)
+
+    felt_lower = DEFAULT_FELT_LOWER.copy()
+    felt_upper = DEFAULT_FELT_UPPER.copy()
+
+    while True:
+        h_low = cv2.getTrackbarPos("H Low", window)
+        s_low = cv2.getTrackbarPos("S Low", window)
+        v_low = cv2.getTrackbarPos("V Low", window)
+        h_high = cv2.getTrackbarPos("H High", window)
+        s_high = cv2.getTrackbarPos("S High", window)
+        v_high = cv2.getTrackbarPos("V High", window)
+
+        felt_lower = np.array([h_low, s_low, v_low])
+        felt_upper = np.array([h_high, s_high, v_high])
+
+        hsv = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2HSV)
+        mask = create_felt_mask(hsv, felt_lower, felt_upper)
+        preview = cv2.bitwise_and(frame_bgr, frame_bgr, mask=mask)
+        cv2.imshow(window, preview)
+
+        key = cv2.waitKey(1) & 0xFF
+        if key == ord("s"):
+            break
+        if key == ord("q"):
+            felt_lower = DEFAULT_FELT_LOWER.copy()
+            felt_upper = DEFAULT_FELT_UPPER.copy()
+            break
+
+    cv2.destroyWindow(window)
+    return felt_lower, felt_upper

--- a/ball_tracker.py
+++ b/ball_tracker.py
@@ -1,0 +1,333 @@
+"""Ball detection, tracking, and rack heuristics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Optional
+
+import cv2
+import numpy as np
+
+from ball_colors import (
+    CLASSIFICATION_CONFIDENCE_THRESHOLD,
+    DEFAULT_FELT_LOWER,
+    DEFAULT_FELT_UPPER,
+    ClassificationResult,
+    classify_ball,
+    create_felt_mask,
+)
+
+MAX_MISSED_FRAMES = 15
+RACK_CLUSTER_MIN_BALLS = 5
+RACK_CLUSTER_MAX_DISTANCE_FACTOR = 2.5
+
+
+@dataclass
+class Detection:
+    cx: int
+    cy: int
+    radius: int
+    classification: ClassificationResult = field(
+        default_factory=lambda: ClassificationResult(None, 0.0, "Unknown")
+    )
+
+
+@dataclass
+class Track:
+    track_id: int
+    cx: int
+    cy: int
+    radius: int
+    ball_number: Optional[int] = None
+    label: str = "Unknown"
+    confidence: float = 0.0
+    missed_frames: int = 0
+
+    def update(
+        self,
+        detection: Detection,
+        persist_label: bool = True,
+    ) -> None:
+        self.cx = detection.cx
+        self.cy = detection.cy
+        self.radius = detection.radius
+        self.missed_frames = 0
+
+        new_conf = detection.classification.confidence
+        new_number = detection.classification.ball_number
+        new_label = detection.classification.label
+
+        if new_number is not None and new_conf >= CLASSIFICATION_CONFIDENCE_THRESHOLD:
+            if not persist_label or self.ball_number is None or new_conf > self.confidence:
+                self.ball_number = new_number
+                self.label = new_label
+                self.confidence = new_conf
+        elif not persist_label or self.ball_number is None:
+            self.label = new_label
+            self.confidence = new_conf
+
+
+class BallTracker:
+    """Detect pool balls and track them across frames."""
+
+    def __init__(
+        self,
+        felt_lower: Optional[np.ndarray] = None,
+        felt_upper: Optional[np.ndarray] = None,
+    ) -> None:
+        self.felt_lower = felt_lower if felt_lower is not None else DEFAULT_FELT_LOWER.copy()
+        self.felt_upper = felt_upper if felt_upper is not None else DEFAULT_FELT_UPPER.copy()
+        self.tracks: list[Track] = []
+        self._next_id = 1
+        self._frame_width = 0
+
+    def _is_on_table(
+        self,
+        felt_mask: np.ndarray,
+        cx: int,
+        cy: int,
+        radius: int,
+    ) -> bool:
+        """Return True when a ball center lies within the felt play area."""
+        ys, xs = np.where(felt_mask > 0)
+        if len(xs) == 0:
+            return True
+
+        margin = radius
+        x1, x2 = int(xs.min()), int(xs.max())
+        y1, y2 = int(ys.min()), int(ys.max())
+        return (
+            x1 + margin <= cx <= x2 - margin
+            and y1 + margin <= cy <= y2 - margin
+        )
+
+    def _radius_bounds(self) -> tuple[int, int]:
+        min_r = max(6, int(self._frame_width * 0.015))
+        max_r = max(min_r + 2, int(self._frame_width * 0.04))
+        return min_r, max_r
+
+    def detect_balls(self, frame_bgr: np.ndarray) -> list[Detection]:
+        """Find ball candidates using Hough circles on the felt region."""
+        self._frame_width = frame_bgr.shape[1]
+        min_radius, max_radius = self._radius_bounds()
+        min_dist = max(min_radius * 2, int(min_radius * 1.8))
+
+        hsv = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2HSV)
+        felt_mask = create_felt_mask(hsv, self.felt_lower, self.felt_upper)
+
+        gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
+        gray = cv2.GaussianBlur(gray, (9, 9), 2)
+
+        circles = cv2.HoughCircles(
+            gray,
+            cv2.HOUGH_GRADIENT,
+            dp=1.2,
+            minDist=min_dist,
+            param1=50,
+            param2=28,
+            minRadius=min_radius,
+            maxRadius=max_radius,
+        )
+
+        detections: list[Detection] = []
+        if circles is None:
+            return detections
+
+        for circle in np.round(circles[0]).astype(int):
+            cx, cy, radius = int(circle[0]), int(circle[1]), int(circle[2])
+            if not self._is_on_table(felt_mask, cx, cy, radius):
+                continue
+
+            classification = classify_ball(frame_bgr, hsv, cx, cy, radius)
+            detections.append(
+                Detection(cx=cx, cy=cy, radius=radius, classification=classification)
+            )
+
+        return self._non_max_suppression(detections)
+
+    def _non_max_suppression(self, detections: list[Detection]) -> list[Detection]:
+        """Remove overlapping duplicate detections, keeping higher-confidence ones."""
+        if len(detections) <= 1:
+            return detections
+
+        detections = sorted(
+            detections,
+            key=lambda d: d.classification.confidence,
+            reverse=True,
+        )
+        kept: list[Detection] = []
+        for det in detections:
+            overlap = any(
+                np.hypot(det.cx - existing.cx, det.cy - existing.cy)
+                < (det.radius + existing.radius) * 0.6
+                for existing in kept
+            )
+            if not overlap:
+                kept.append(det)
+        return kept
+
+    def _match_distance(self, track: Track, detection: Detection) -> float:
+        return float(np.hypot(track.cx - detection.cx, track.cy - detection.cy))
+
+    def _max_match_distance(self, track: Track) -> float:
+        return track.radius * 1.5
+
+    def update(self, frame_bgr: np.ndarray) -> list[Track]:
+        """Run detection, associate with existing tracks, apply rack heuristics."""
+        detections = self.detect_balls(frame_bgr)
+        detections = self._apply_rack_heuristics(detections)
+        self._associate(detections)
+        return [t for t in self.tracks if t.missed_frames == 0]
+
+    def _associate(self, detections: list[Detection]) -> None:
+        unmatched_tracks = set(range(len(self.tracks)))
+        unmatched_detections = set(range(len(detections)))
+
+        pairs: list[tuple[float, int, int]] = []
+        for ti in unmatched_tracks:
+            track = self.tracks[ti]
+            for di in unmatched_detections:
+                detection = detections[di]
+                dist = self._match_distance(track, detection)
+                if dist <= self._max_match_distance(track):
+                    pairs.append((dist, ti, di))
+
+        pairs.sort(key=lambda item: item[0])
+
+        matched_tracks: set[int] = set()
+        matched_detections: set[int] = set()
+        for _, ti, di in pairs:
+            if ti in matched_tracks or di in matched_detections:
+                continue
+            self.tracks[ti].update(detections[di])
+            matched_tracks.add(ti)
+            matched_detections.add(di)
+
+        for ti in unmatched_tracks - matched_tracks:
+            self.tracks[ti].missed_frames += 1
+
+        for di in unmatched_detections - matched_detections:
+            detection = detections[di]
+            track = Track(
+                track_id=self._next_id,
+                cx=detection.cx,
+                cy=detection.cy,
+                radius=detection.radius,
+            )
+            track.update(detection, persist_label=False)
+            self.tracks.append(track)
+            self._next_id += 1
+
+        self.tracks = [t for t in self.tracks if t.missed_frames <= MAX_MISSED_FRAMES]
+
+    def _apply_rack_heuristics(self, detections: list[Detection]) -> list[Detection]:
+        """
+        When balls form a tight cluster (rack), assign 1 to apex and 9 to center
+        for low-confidence classifications.
+        """
+        if len(detections) < RACK_CLUSTER_MIN_BALLS:
+            return detections
+
+        positions = np.array([[d.cx, d.cy] for d in detections])
+        centroid = positions.mean(axis=0)
+        avg_radius = float(np.mean([d.radius for d in detections]))
+        max_dist = avg_radius * RACK_CLUSTER_MAX_DISTANCE_FACTOR
+
+        cluster_indices = [
+            i
+            for i, det in enumerate(detections)
+            if np.hypot(det.cx - centroid[0], det.cy - centroid[1]) <= max_dist * 2
+        ]
+        if len(cluster_indices) < RACK_CLUSTER_MIN_BALLS:
+            return detections
+
+        cluster = [detections[i] for i in cluster_indices]
+        apex = min(cluster, key=lambda d: d.cy)
+        center = min(
+            cluster,
+            key=lambda d: np.hypot(d.cx - centroid[0], d.cy - centroid[1]),
+        )
+
+        result = list(detections)
+        for i, det in enumerate(result):
+            if det.classification.confidence >= CLASSIFICATION_CONFIDENCE_THRESHOLD:
+                continue
+            if det.cx == apex.cx and det.cy == apex.cy:
+                result[i] = Detection(
+                    det.cx,
+                    det.cy,
+                    det.radius,
+                    ClassificationResult(1, 0.5, "1"),
+                )
+            elif det.cx == center.cx and det.cy == center.cy:
+                result[i] = Detection(
+                    det.cx,
+                    det.cy,
+                    det.radius,
+                    ClassificationResult(9, 0.5, "9"),
+                )
+
+        return result
+
+
+def scale_tracks_for_display(tracks: list[Track], scale: float) -> list[Track]:
+    """Return track copies with coordinates mapped back to full-resolution frame."""
+    if scale == 1.0:
+        return tracks
+
+    inv = 1.0 / scale
+    return [
+        replace(
+            track,
+            cx=int(track.cx * inv),
+            cy=int(track.cy * inv),
+            radius=int(track.radius * inv),
+        )
+        for track in tracks
+    ]
+
+
+def draw_tracks(frame_bgr: np.ndarray, tracks: list[Track]) -> np.ndarray:
+    """Draw highlight circles and labels for active tracks."""
+    output = frame_bgr.copy()
+    for track in tracks:
+        color = _label_color(track.ball_number)
+        cv2.circle(output, (track.cx, track.cy), track.radius + 2, color, 2)
+        cv2.circle(output, (track.cx, track.cy), 2, color, -1)
+
+        if track.ball_number is not None:
+            text = str(track.ball_number)
+        else:
+            text = f"Ball {track.track_id}"
+
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        scale = max(0.4, track.radius / 30)
+        thickness = max(1, int(scale * 2))
+        (text_w, text_h), _ = cv2.getTextSize(text, font, scale, thickness)
+        tx = track.cx - text_w // 2
+        ty = track.cy - track.radius - 8
+        cv2.rectangle(
+            output,
+            (tx - 2, ty - text_h - 2),
+            (tx + text_w + 2, ty + 2),
+            (0, 0, 0),
+            -1,
+        )
+        cv2.putText(output, text, (tx, ty), font, scale, color, thickness, cv2.LINE_AA)
+
+    return output
+
+
+def _label_color(ball_number: Optional[int]) -> tuple[int, int, int]:
+    palette = {
+        1: (0, 220, 255),
+        2: (255, 120, 0),
+        3: (0, 0, 255),
+        4: (255, 0, 200),
+        5: (0, 140, 255),
+        6: (0, 200, 0),
+        7: (0, 0, 140),
+        8: (200, 200, 200),
+        9: (0, 255, 255),
+    }
+    return palette.get(ball_number, (255, 255, 255))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python>=4.8.0
+numpy>=1.24.0

--- a/track_9ball_rack.py
+++ b/track_9ball_rack.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Track and label 9-ball rack balls in top-down pool table video."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+
+from ball_colors import run_calibration
+from ball_tracker import BallTracker, draw_tracks, scale_tracks_for_display
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Track pool balls in a top-down 9-ball rack video using OpenCV."
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to input video file",
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to save annotated output video (MP4)",
+    )
+    parser.add_argument(
+        "--display",
+        action="store_true",
+        help="Show live preview window",
+    )
+    parser.add_argument(
+        "--calibrate",
+        action="store_true",
+        help="Run interactive HSV calibration on the first frame",
+    )
+    parser.add_argument(
+        "--scale",
+        type=float,
+        default=1.0,
+        help="Resize factor for processing (e.g. 0.5 for faster processing)",
+    )
+    return parser.parse_args()
+
+
+def open_video(path: str) -> cv2.VideoCapture:
+    cap = cv2.VideoCapture(path)
+    if not cap.isOpened():
+        print(f"Error: could not open video '{path}'", file=sys.stderr)
+        sys.exit(1)
+    return cap
+
+
+def create_writer(
+    output_path: str,
+    fps: float,
+    frame_size: tuple[int, int],
+) -> cv2.VideoWriter:
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(output_path, fourcc, fps, frame_size)
+    if not writer.isOpened():
+        print(f"Error: could not create output video '{output_path}'", file=sys.stderr)
+        sys.exit(1)
+    return writer
+
+
+def resize_frame(frame, scale: float):
+    if scale == 1.0:
+        return frame
+    return cv2.resize(frame, None, fx=scale, fy=scale, interpolation=cv2.INTER_AREA)
+
+
+def process_video(args: argparse.Namespace) -> None:
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: input file not found '{input_path}'", file=sys.stderr)
+        sys.exit(1)
+
+    cap = open_video(str(input_path))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    ret, first_frame = cap.read()
+    if not ret:
+        print("Error: could not read first frame from video", file=sys.stderr)
+        sys.exit(1)
+
+    felt_lower = None
+    felt_upper = None
+    if args.calibrate:
+        felt_lower, felt_upper = run_calibration(first_frame)
+
+    tracker = BallTracker(felt_lower=felt_lower, felt_upper=felt_upper)
+
+    writer = None
+    if args.output:
+        writer = create_writer(args.output, fps, (frame_width, frame_height))
+
+    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    frame_idx = 0
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        proc_frame = resize_frame(frame, args.scale)
+        tracks = tracker.update(proc_frame)
+        display_tracks = scale_tracks_for_display(tracks, args.scale)
+        annotated = draw_tracks(frame, display_tracks)
+
+        if writer is not None:
+            writer.write(annotated)
+
+        if args.display:
+            cv2.imshow("9-Ball Tracker", annotated)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                break
+
+        frame_idx += 1
+
+    cap.release()
+    if writer is not None:
+        writer.release()
+    if args.display:
+        cv2.destroyAllWindows()
+
+    print(f"Processed {frame_idx} frames.")
+
+
+def main() -> None:
+    args = parse_args()
+    process_video(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a standalone OpenCV-based tool that detects and tracks pool balls in top-down table video, highlights each ball with a colored circle, and overlays numbered labels (1–9) when color classification is confident.

## What's included

- **`track_9ball_rack.py`** — CLI entry point with `--input`, `--output`, `--display`, `--calibrate`, and `--scale` flags
- **`ball_colors.py`** — HSV color ranges for standard APA/BCA balls, stripe detection (1 vs 9), and interactive felt calibration
- **`ball_tracker.py`** — Hough circle detection, centroid tracking across frames, and rack geometry heuristics
- **`requirements.txt`** — `opencv-python`, `numpy`
- **`README.md`** — Setup, usage, and tuning notes

## How it works

1. Masks the felt play area to reduce false positives
2. Detects balls via Hough circle transform
3. Classifies ball numbers from HSV color in each ball's center
4. Distinguishes solid yellow (1) from striped yellow (9) via white-band ratio
5. Tracks balls across frames with nearest-neighbor association
6. Applies rack heuristics (apex → 1, center → 9) when color confidence is low

## Usage

```bash
pip install -r requirements.txt
python track_9ball_rack.py --input video.mp4 --output annotated.mp4 --display
```

## Testing

- Verified CLI (`--help`) and imports
- Smoke-tested on a synthetic top-down frame (9/9 balls detected)

## Limitations

- Best results with fixed overhead camera and consistent lighting
- No deep-learning model — fast and lightweight, but not competition-grade
- 1 vs 9 and 7 vs 8 can be misclassified under poor lighting; use `--calibrate` to tune HSV ranges

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-237d6225-244d-401f-9a54-97dbe4eee317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-237d6225-244d-401f-9a54-97dbe4eee317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

